### PR TITLE
docs(navigation.html) fix spelling error

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,6 +1,6 @@
 <nav>
   <a href="{{ site.baseurl }}/about/">Taustatietoa</a>
   <a href="{{ site.baseurl }}/contact/">Anna palautetta</a>
-  <a href="https://github.com/okffi/open-api-definition/issues">Github</a>
+  <a href="https://github.com/okffi/open-api-definition/issues">GitHub</a>
   <a href="{{ site.baseurl }}/archive/">Arkisto</a>
 </nav>


### PR DESCRIPTION
Fix spelling of `Github` brand name to the official `GitHub` spelling.